### PR TITLE
Fix invalid annotation for channel_id

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -593,7 +593,7 @@ class AbstractConnection extends AbstractChannel
      * Fetches a channel object identified by the numeric channel_id, or
      * create that object if it doesn't already exist.
      *
-     * @param string $channel_id
+     * @param integer $channel_id
      * @return AMQPChannel
      */
     public function channel($channel_id = null)


### PR DESCRIPTION
\PhpAmqpLib\Connection\AbstractConnection::channel() param $channel_id changed from `string` to `integer`.

Non-integer value is causing error:

```
Error on AMQP connection <0.390.0> (127.0.0.1:51356 -> 127.0.0.1:5672, vhost: '/', user: 'guest', state: running), channel 0:
operation channel.open caused a connection exception channel_error: "unexpected method in connection state running"
```
